### PR TITLE
Fix for CPU/Memory column overlap

### DIFF
--- a/src/ui/components.rs
+++ b/src/ui/components.rs
@@ -1070,8 +1070,29 @@ fn node_state_color(node: &Node) -> ratatui::style::Color {
 }
 
 fn render_nodes_tab(frame: &mut Frame, app: &App, area: Rect) {
+    // These two columns hold numbers, so they can't be truncated like the
+    // text columns. Size them to the widest value (with the old widths as
+    // minimums) so big CPU/RAM figures keep a space before the next column
+    // instead of merging into it, e.g. "128/1282766G/1511G".
+    let cpu_w = app
+        .nodes
+        .iter()
+        .map(|n| format!("{}/{}", n.cpus_alloc, n.cpus_total).len() + 1)
+        .max()
+        .unwrap_or(0)
+        .max(7);
+    let mem_w = app
+        .nodes
+        .iter()
+        .map(|n| format!("{}/{}", fmt_gb(n.free_mem_mb), fmt_gb(n.memory_mb)).len() + 1)
+        .max()
+        .unwrap_or(0)
+        .max(12);
+    // The CPUS header spans the 6-cell bar plus the value column.
+    let cpu_col = 7 + cpu_w;
+
     let header = format!(
-        "  {:<18}{:<10}{:<14}{:<12}{:<20}PART",
+        "  {:<18}{:<10}{:<cpu_col$}{:<mem_w$}{:<20}PART",
         "NODE", "STATE", "CPUS", "MEM f/t", "GPU"
     );
 
@@ -1098,12 +1119,15 @@ fn render_nodes_tab(frame: &mut Frame, app: &App, area: Rect) {
                 color,
             ));
             spans.push(Span::styled(
-                format!(" {:<7}", format!("{}/{}", node.cpus_alloc, node.cpus_total)),
+                format!(
+                    " {:<cpu_w$}",
+                    format!("{}/{}", node.cpus_alloc, node.cpus_total)
+                ),
                 base.fg(theme::MUTED),
             ));
             spans.push(Span::styled(
                 format!(
-                    "{:<12}",
+                    "{:<mem_w$}",
                     format!("{}/{}", fmt_gb(node.free_mem_mb), fmt_gb(node.memory_mb))
                 ),
                 base.fg(theme::MUTED),

--- a/tests/render_smoke.rs
+++ b/tests/render_smoke.rs
@@ -113,6 +113,56 @@ fn nodes_tab_renders_node_row() {
 }
 
 #[test]
+fn nodes_tab_keeps_space_before_mem_with_wide_cpu_values() {
+    // A 128-core node fills the old 7-char CPU column exactly, leaving no
+    // gap before the memory column: "128/1282766G/1511G".
+    let mut app = App::new();
+    app.active_tab = ActiveTab::Nodes;
+    app.nodes = vec![Node {
+        name: "cpu-node-01".into(),
+        state: "allocated".into(),
+        cpus_alloc: 128,
+        cpus_idle: 0,
+        cpus_other: 0,
+        cpus_total: 128,
+        memory_mb: Some(1_547_264),   // 1511G
+        free_mem_mb: Some(2_833_000), // 2766G
+        gres: Some("tmpfs:7T".into()),
+        partition: "cpu".into(),
+    }];
+    let text = rendered_text(&app);
+    assert!(
+        text.contains("128/128 2766G/1511G"),
+        "CPU and MEM columns must not merge, got: {text}"
+    );
+}
+
+#[test]
+fn nodes_tab_keeps_space_before_gpu_with_wide_mem_values() {
+    // A multi-TB node overflows the old 12-char MEM column, merging it with
+    // the GPU column: "11264G/11264Ggpu:a100:4".
+    let mut app = App::new();
+    app.active_tab = ActiveTab::Nodes;
+    app.nodes = vec![Node {
+        name: "fat-node-01".into(),
+        state: "idle".into(),
+        cpus_alloc: 0,
+        cpus_idle: 64,
+        cpus_other: 0,
+        cpus_total: 64,
+        memory_mb: Some(11_534_336), // 11264G
+        free_mem_mb: Some(11_534_336),
+        gres: Some("gpu:a100:4".into()),
+        partition: "gpu".into(),
+    }];
+    let text = rendered_text(&app);
+    assert!(
+        text.contains("11264G/11264G gpu:a100:4"),
+        "MEM and GPU columns must not merge, got: {text}"
+    );
+}
+
+#[test]
 fn partitions_tab_marks_default_and_shows_limit() {
     let mut app = App::new();
     app.active_tab = ActiveTab::Partitions;


### PR DESCRIPTION
Solves: https://github.com/hill/lazyslurm/issues/9

The column rendering for CPU and memory is now dynamic based on the size of the text itself. This way we avoid the CPU/memory text overlap, and ensure a whitespace between both columns.

This PR also adds a test for this issue.

<img width="654" height="452" alt="image" src="https://github.com/user-attachments/assets/d40dd237-a9c3-474a-86a8-7f399b0b327b" />
